### PR TITLE
Add colors for my specific Network equipments (Schirrms)

### DIFF
--- a/dist/molkobain-datacenter-view/molkobain-datacenter-view/common/css/datacenter-view.css
+++ b/dist/molkobain-datacenter-view/molkobain-datacenter-view/common/css/datacenter-view.css
@@ -83,6 +83,9 @@
 .molkobain-datacenter-view .mdv-body .mdv-controls .mdv-legend ul li[data-class="NetworkDevice"]::before {
   background-color: #c85454;
 }
+.molkobain-datacenter-view .mdv-body .mdv-controls .mdv-legend ul li[data-class="GenericCommDevice"]::before {
+  background-color: #c85454;
+}
 .molkobain-datacenter-view .mdv-body .mdv-controls .mdv-legend ul li[data-class="SANSwitch"]::before {
   background-color: lightsalmon;
 }
@@ -283,6 +286,9 @@
   background-color: #3f627e;
 }
 .molkobain-datacenter-view .mdv-body .mdv-device[data-class="NetworkDevice"] {
+  background-color: #c85454;
+}
+.molkobain-datacenter-view .mdv-body .mdv-device[data-class="GenericCommDevice"] {
   background-color: #c85454;
 }
 .molkobain-datacenter-view .mdv-body .mdv-device[data-class="SANSwitch"] {

--- a/dist/molkobain-datacenter-view/molkobain-datacenter-view/common/css/datacenter-view.scss
+++ b/dist/molkobain-datacenter-view/molkobain-datacenter-view/common/css/datacenter-view.scss
@@ -75,6 +75,9 @@
 						&[data-class="NetworkDevice"]::before{
 							background-color: $obj-class-networkdevice-bg-color;
 						}
+						&[data-class="GenericCommDevice"]::before{
+							background-color: $obj-class-networkdevice-bg-color;
+						}
 						&[data-class="SANSwitch"]::before{
 							background-color: $obj-class-sanswitch-bg-color;
 						}
@@ -322,6 +325,9 @@
 				background-color: $obj-class-server-bg-color;
 			}
 			&[data-class="NetworkDevice"]{
+				background-color: $obj-class-networkdevice-bg-color;
+			}
+			&[data-class="GenericCommDevice"]{
 				background-color: $obj-class-networkdevice-bg-color;
 			}
 			&[data-class="SANSwitch"]{


### PR DESCRIPTION
Hi Molkobain,

Every time I download a new version of your (wondeful) datacenterview, I have to modify those two files to have my network equipments displayed in the correct color (and not the reserved green for unknown device types).

Could you be kind enough to add that change upstream ? 

TIA,

Schirrms (Doing his first pull request :))